### PR TITLE
Change random access test filename to avoid reopening same file

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(createRandomAccessFile, options) {
   })
 
   tape("random access write and read", function(t) {
-    createRandomAccessFile("write-and-read.txt", null, function(file) {
+    createRandomAccessFile("random-access.txt", null, function(file) {
       file.write(10, Buffer.from("hi"), function(err) {
         t.error(err, "no error")
         file.write(0, Buffer.from("hello"), function(err) {


### PR DESCRIPTION
This was probably a copy/paste error. `write-and-read.txt` is the name of the first test file, and this test overwrites the values from the first test.

Testing re-opening and reading/writing from the same file can be activated using `options.reopen`, so this test should have a different file name (like all other tests).