### PR TITLE
Add a test for simultaneous reads/writes

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,4 +267,43 @@ module.exports = function(createRandomAccessFile, options) {
       )
     })
   }
+
+  tape("simultaneous writes and reads", function(t) {
+    let i = 0
+    createRandomAccessFile("write-and-read-simultaneous.txt", null, function(file) {
+      file.write(0, Buffer.from("hello"), function(err) {
+        t.error(err, "no error")
+        file.read(0, 5, function(err, buf) {
+          t.error(err, "no error")
+          t.same(buf, Buffer.from("hello"))
+          i++
+          if (i == 3) {
+            file.destroy(t.end)
+          }
+        })
+      })
+      file.write(10, Buffer.from("hallo"), function(err) {
+        t.error(err, "no error")
+        file.read(10, 5, function(err, buf) {
+          t.error(err, "no error")
+          t.same(buf, Buffer.from("hallo"))
+          i++
+          if (i == 3) {
+            file.destroy(t.end)
+          }
+        })
+      })
+      file.write(5, Buffer.from("hola!"), function(err) {
+        t.error(err, "no error")
+        file.read(5, 5, function(err, buf) {
+          t.error(err, "no error")
+          t.same(buf, Buffer.from("hola!"))
+          i++
+          if (i == 3) {
+            file.destroy(t.end)
+          }
+        })
+      })
+    })
+  })
 }


### PR DESCRIPTION
This test works fine in random-access-file, but breaks in my project https://github.com/lachenmayer/random-access-key-value because I check the database to read the "current" value, and sometimes the previous write has not yet completed.

I noticed this when trying to use random-access-key-value with a hypertrie as storage backend ([as in this gist](https://gist.github.com/lachenmayer/8af38f3b137b68a79ffe9820b9965b72)). The root cause is that hypercore writes to some `tree` location `3`, and then writes the new root to `tree` location `2` instantly, apparently without waiting for completion from the first write.