### PR TITLE
Add basic tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -158,6 +158,23 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
@@ -185,6 +202,25 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "random-access-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.0.1.tgz",
+      "integrity": "sha512-nb4fClpzoUY+v1SHrro+9yykN90eMA1rc+xM39tnZ5R3BgFY+J/NxPZ0KuUpishEsvnwou9Fvm2wa3cjeuG7vg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "random-access-storage": "^1.1.1"
+      }
+    },
+    "random-access-storage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
+      "integrity": "sha512-pdS9Mcb9TB7oICypPRALlheaSuszuAKmLVEPKJMuYor7R/zDuHh5ALuQoS+ox31XRwQUL+tDwWH2GPdyspwelA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3"
+      }
     },
     "resolve": {
       "version": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "tape": "^4.9.1"
   },
   "devDependencies": {
+    "lint-staged": "^7.2.0",
     "prettier": "^1.9.2",
-    "lint-staged": "^7.2.0"
+    "random-access-file": "^2.0.1"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     ]
   },
   "scripts": {
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "test": "node test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+var test = require("random-access-test")
+var randomAccess = require("random-access-file") // Or your package instead
+var path = require("path")
+var os = require("os")
+
+var tmp = path.join(
+  os.tmpdir(),
+  "random-access-file-" + process.pid + "-" + Date.now()
+)
+test(
+  function(name, options, callback) {
+    const file = path.join(tmp, name)
+    callback(randomAccess(file, options))
+  },
+  {
+    // Choose which test to exercise
+    reopen: true, // tests that re-open same file (not applicable to ram)
+    content: false, // tests that populates with options.content
+    del: true, // tests that excersise advisory del API
+    writable: true, // tests that excersise open with `options.writable`
+    size: true, // tests that excersise open with `options.size`
+    truncate: true // tests that excersise open with `options.truncate`
+  }
+)


### PR DESCRIPTION
I added some new tests in https://github.com/random-access-storage/random-access-test/pull/5 and I just wanted to double check that I didn't mess up the test implementation.

This just adds the example script as a basic test.

Some of the existing tests are failing, even with random-access-file:

```
# read empty
not ok 4 no error
  ---
    operator: error
    expected: |-
      undefined
    actual: |-
      { [Error: ENOENT: no such file or directory, open '/var/folders/z8/xq1r3qcd7szbpx1_77xsgpqc0000gn/T/random-access-file-58676-1531846996824/create-empty.txt'] errno: -2, code: 'ENOENT', syscall: 'open', path: '/var/folders/z8/xq1r3qcd7szbpx1_77xsgpqc0000gn/T/random-access-file-58676-1531846996824/create-empty.txt' }
    at: Request._callback (/Users/harry/Documents/node_modules/random-access-test/index.js:23:11)
    stack: |-
      Error: ENOENT: no such file or directory, open '/var/folders/z8/xq1r3qcd7szbpx1_77xsgpqc0000gn/T/random-access-file-58676-1531846996824/create-empty.txt'
  ...
not ok 5 empty buffer
  ---
    operator: deepEqual
    expected: <Buffer >
    actual:   undefined
    at: Request._callback (/Users/harry/Documents/node_modules/random-access-test/index.js:24:11)
    stack: |-
      Error: empty buffer
          at Test.assert [as _assert] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:76:32)
          at Test.tapeDeepEqual (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:421:10)
          at Test.bound [as same] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:76:32)
          at Request._callback (/Users/harry/Documents/node_modules/random-access-test/index.js:24:11)
          at Request.callback (/Users/harry/Documents/node_modules/random-access-test/node_modules/random-access-storage/index.js:161:8)
          at nextTickCallback (/Users/harry/Documents/node_modules/random-access-test/node_modules/random-access-storage/index.js:249:7)
          at process._tickCallback (internal/process/next_tick.js:63:19)
  ...
```

```
# bad truncate
not ok 24 should be truthy
  ---
    operator: ok
    expected: true
    actual:   null
    at: Request._callback (/Users/harry/Documents/node_modules/random-access-test/index.js:133:15)
    stack: |-
      Error: should be truthy
          at Test.assert [as _assert] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:76:32)
          at Test.assert (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:342:10)
          at Test.bound [as ok] (/Users/harry/Documents/node_modules/random-access-test/node_modules/tape/lib/test.js:76:32)
          at Request._callback (/Users/harry/Documents/node_modules/random-access-test/index.js:133:15)
          at Request.callback (/Users/harry/Documents/node_modules/random-access-test/node_modules/random-access-storage/index.js:161:8)
          at ontruncate (/Users/harry/Documents/node_modules/random-access-test/node_modules/random-access-file/index.js:163:9)
          at FSReqWrap.oncomplete (fs.js:145:20)
  ...
```

Not sure what the correct behavior is meant to be.